### PR TITLE
Enabled typecheck for tslint

### DIFF
--- a/packages/react-scripts/scripts/lint.js
+++ b/packages/react-scripts/scripts/lint.js
@@ -1,12 +1,11 @@
 var spawn = require('cross-spawn');
 
 var args = [
-    '--config',
-    'tslint.json',
-    '--exclude',
-    'src/**/*.d.ts',
-    'src/**/*.ts',
-    'src/**/*.tsx'
+    '-t',
+    'verbose',
+    '--project',
+    './tsconfig.json',
+    '--type-check'
 ];
 var proc = spawn('tslint', args, {
     stdio: 'inherit'

--- a/packages/react-scripts/template/tsconfig.json
+++ b/packages/react-scripts/template/tsconfig.json
@@ -13,8 +13,7 @@
         "strictNullChecks": true,
         "target": "es6"
     },
-    "files": [
-        "src/typings.d.ts",
-        "src/index.tsx"
+    "exclude": [
+        "node_modules/**/*"
     ]
 }

--- a/packages/tslint-config-react-app/README.md
+++ b/packages/tslint-config-react-app/README.md
@@ -20,10 +20,8 @@ To use in `create-react-app` we overridden several rules to make it compatible w
 * missing-jsdoc, not useful for an application, it would be for a library
 * no-any, not everything has to be to typed to allow for incrementally introduction of types for eg. 3rd party libraries
 * no-relative-imports, not practical for an application, it would be for a library because it has a package name
-* no-for-in-array, tslint in create-react-app does not do typecheck
 * no-reserved-keywords, redux requires `type` keyword for a action, the rule doesn't allow us to whitelist `type` so we disabled whole rule
 * no-unused-variable:[true, "react"], allow React to be marked used by jsx tags
-* restrict-plus-operands, tslint in create-react-app does not do typecheck
 * quotemark
 
     * single, single quote because its less typing

--- a/packages/tslint-config-react-app/tslint.json
+++ b/packages/tslint-config-react-app/tslint.json
@@ -15,10 +15,8 @@
         "missing-jsdoc": false,
         "no-any": false,
         "no-relative-imports": false,
-        "no-for-in-array": false,
         "no-reserved-keywords": false,
         "no-unused-variable": [true, "react"],
-        "restrict-plus-operands": false,
         "quotemark": [
             true,
             "single",


### PR DESCRIPTION
To get best performance the tsconfig was altered to exclude node_modules instead of including files in src/.

Also the lint format now includes the rule name.

Fixes #23